### PR TITLE
refactor(schema): unify setFrom and getFor methods

### DIFF
--- a/src/Schema.js
+++ b/src/Schema.js
@@ -57,9 +57,22 @@ class Schema {
     this._isLocked = true;
   }
 
-  setPrimaryKey(item: Object, data: Object) {
-    this._setKeyIfUndefined('', item, data);
-    this._setKeyIfUndefined('_', item, data);
+  setPrimaryKey(source: DataSource, item: Object, data: Object) {
+    let prefix;
+    if (source === SOURCE.CLIENT_STORAGE) {
+      prefix = '_';
+    } else if (source === SOURCE.TRANSPORTER) {
+      prefix = '';
+    } else {
+      throw new Error('unsupported source');
+    }
+
+    const key = this._primaryKey[`${prefix}key`];
+    const dataKey = data[key];
+    const itemKey = item[key];
+    if (dataKey !== undefined && itemKey === undefined) {
+      item[key] = dataKey;
+    }
   }
 
   _setFromState(item: Object, data: Object, options: Object): Promise {
@@ -220,15 +233,6 @@ class Schema {
     Schema._mergeFromSet({ item, filteredData, options }, observables);
     const promises = this._setForeignValues(item, data, keyPrefix, options);
     return Promise.all(promises).then(() => item);
-  }
-
-  _setKeyIfUndefined(prefix: string, item: Object, data: Object) {
-    const key = this._primaryKey[`${prefix}key`];
-    const dataKey = data[key];
-    const itemKey = item[key];
-    if (dataKey !== undefined && itemKey === undefined) {
-      item[key] = dataKey;
-    }
   }
 
   static _mergeFromSet({ item, filteredData, options }, observables) {

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -306,20 +306,17 @@ class Schema {
    *
    * initialData is an object with data, that has to be in the result as well
    */
-  // getForTransporter(item, initialData){}
-  /**
-   * same as getForTransporter but for the clientStorage
-   */
-  // getForClientStorage(item, initialData){}
+  // getFor(source: DataSource, item: Object, initialData: Object) {
+  //
+  // }
+
   /**
    * gets the transporter primary key. The function is only called when the key
    * already exists, so this should be sync. returns { <key_name> : <key_value> }
    */
-  // getPrimaryKeyForTransporter(item) {}
-  /**
-   * same as getPrimaryKeyForTransporter but for clientStorage
-   */
-  // getPrimaryKeyForClientStorage(item) {}
+  // getPrimaryKey(source: DataSource, item: Object) {
+  //
+  // }
 }
 
 export default Schema;

--- a/src/Schema.spec.js
+++ b/src/Schema.spec.js
@@ -192,7 +192,7 @@ describe('Schema', function () {
       _id: 567,
     };
 
-    schema.setPrimaryKey(item, { id: 123 });
+    schema.setPrimaryKey(SOURCE.TRANSPORTER, item, { _id: 120, id: 123 });
     expect(item).toEqual({
       brand: 'Volkswagen',
       id: 123,
@@ -215,7 +215,7 @@ describe('Schema', function () {
       _id: 567,
     };
 
-    schema.setPrimaryKey(item, { id: 123 });
+    schema.setPrimaryKey(SOURCE.TRANSPORTER, item, { id: 123 });
     expect(item).toEqual({
       brand: 'Volkswagen',
       id: 9001,
@@ -237,7 +237,7 @@ describe('Schema', function () {
       id: 456,
     };
 
-    schema.setPrimaryKey(item, { _id: 123 });
+    schema.setPrimaryKey(SOURCE.CLIENT_STORAGE, item, { id: 123, _id: 123 });
     expect(item).toEqual({
       brand: 'Volkswagen',
       id: 456,
@@ -260,12 +260,32 @@ describe('Schema', function () {
       _id: 9001,
     };
 
-    schema.setPrimaryKey(item, { _id: 123 });
+    schema.setPrimaryKey(SOURCE.CLIENT_STORAGE, item, { _id: 123 });
     expect(item).toEqual({
       brand: 'Volkswagen',
       id: 456,
       _id: 9001,
     });
+  });
+
+  it('should throw error when primary key for unknown source should be set', function () {
+    const inputDefinition = {
+      properties: {
+        brand: String,
+      },
+    };
+
+    const schema = new Schema(inputDefinition);
+
+    const item = {
+      brand: 'Volkswagen',
+      id: 456,
+      _id: 9001,
+    };
+
+    expect(() => {
+      schema.setPrimaryKey(SOURCE.STATE, item, { _id: 123 });
+    }).toThrow(new Error('unsupported source'));
   });
 
   it('should get observables', function (done) {


### PR DESCRIPTION
Adds source parameter to following methods:
* setFrom()
* getFor()
* setPrimaryKey()
* getPrimaryKey()

The getters are not yet implemented, therefore commented out.

Fixes #14 